### PR TITLE
Progress problem

### DIFF
--- a/base-adapter-helper/src/main/java/com/joanzapata/android/BaseAdapterHelper.java
+++ b/base-adapter-helper/src/main/java/com/joanzapata/android/BaseAdapterHelper.java
@@ -245,8 +245,8 @@ public class BaseAdapterHelper {
      */
     public BaseAdapterHelper setProgress(int viewId, int progress, int max) {
         ProgressBar view = retrieveView(viewId);
-        view.setProgress(progress);
         view.setMax(max);
+        view.setProgress(progress);
         return this;
     }
 
@@ -283,8 +283,8 @@ public class BaseAdapterHelper {
      */
     public BaseAdapterHelper setRating(int viewId, float rating, int max){
         RatingBar view = retrieveView(viewId);
-        view.setRating(rating);
         view.setMax(max);
+        view.setRating(rating);
         return this;
     }
 


### PR DESCRIPTION
Fixes a problem, when setting up initial progress greater than max progress.
E.g. when using `setProgress(view, 200, 300)`, but max progress wasn't changed before and is 100, as a result we get progress 100 of 300.
