### PR TITLE
change convert position

### DIFF
--- a/base-adapter-helper/src/main/java/com/joanzapata/android/BaseQuickAdapter.java
+++ b/base-adapter-helper/src/main/java/com/joanzapata/android/BaseQuickAdapter.java
@@ -98,8 +98,8 @@ public abstract class BaseQuickAdapter<T, H extends BaseAdapterHelper> extends B
         if (getItemViewType(position) == 0) {
             final H helper = getAdapterHelper(position, convertView, parent);
             T item = getItem(position);
-            helper.setAssociatedObject(item);
             convert(helper, item);
+            helper.setAssociatedObject(item);
             return helper.getView();
         }
 


### PR DESCRIPTION
When I use EnhancedQuickAdapter, you add 'itemChanged' attribute, this is the parameter in 'convert' function, I think this attribute means it should be 'true' when adapting the new view. But it always 'false'. So I read your source code, I find you call 'convert(helper, item);' after 'helper.setAssociatedObject(item);'. So when you call 'convert', 'helper.associatedObject' has been set to 'item'. So 'itemChanged' always be 'false'. When I put 'convert(helper, item);' before ''helper.setAssociatedObject(item);'. 'itemChanged' has the true meaning.